### PR TITLE
Add ability to ignore dynamodb read and write capacity changes

### DIFF
--- a/aws/resource_aws_dynamodb_table.go
+++ b/aws/resource_aws_dynamodb_table.go
@@ -97,9 +97,29 @@ func resourceAwsDynamoDbTable() *schema.Resource {
 			"write_capacity": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if old != "" && d.Get("autoscaled_write_capacity").(bool) {
+						return true
+					}
+					return false
+				},
+			},
+			"autoscaled_write_capacity": {
+				Type:     schema.TypeBool,
+				Optional: true,
 			},
 			"read_capacity": {
 				Type:     schema.TypeInt,
+				Optional: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if old != "" && d.Get("autoscaled_read_capacity").(bool) {
+						return true
+					}
+					return false
+				},
+			},
+			"autoscaled_read_capacity": {
+				Type:     schema.TypeBool,
 				Optional: true,
 			},
 			"attribute": {
@@ -193,8 +213,16 @@ func resourceAwsDynamoDbTable() *schema.Resource {
 							Type:     schema.TypeInt,
 							Optional: true,
 						},
+						"autoscaled_write_capacity": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
 						"read_capacity": {
 							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"autoscaled_read_capacity": {
+							Type:     schema.TypeBool,
 							Optional: true,
 						},
 						"hash_key": {

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -3919,6 +3919,16 @@ func diffDynamoDbGSI(oldGsi, newGsi []interface{}, billingMode string) (ops []*d
 
 			oldWriteCapacity, oldReadCapacity := oldMap["write_capacity"].(int), oldMap["read_capacity"].(int)
 			newWriteCapacity, newReadCapacity := newMap["write_capacity"].(int), newMap["read_capacity"].(int)
+
+			// Autoscaling is set up individually for read and write.  We can't guarantee it is on for both.
+			if val, ok := newMap["autoscaled_write_capacity"]; ok && val.(bool) {
+				newWriteCapacity = oldWriteCapacity
+			}
+
+			if val, ok := newMap["autoscaled_read_capacity"]; ok && val.(bool) {
+				newReadCapacity = oldReadCapacity
+			}
+
 			capacityChanged := (oldWriteCapacity != newWriteCapacity || oldReadCapacity != newReadCapacity)
 
 			oldAttributes, err := stripCapacityAttributes(oldMap)
@@ -3980,6 +3990,8 @@ func stripCapacityAttributes(in map[string]interface{}) (map[string]interface{},
 
 	delete(m, "write_capacity")
 	delete(m, "read_capacity")
+	delete(m, "autoscaled_write_capacity")
+	delete(m, "autoscaled_read_capacity")
 
 	return m, nil
 }


### PR DESCRIPTION
Added a flag to ignore read and/or write capacity changes for dynamodb tables and GSI for use when using auto-scaling.  Lifecycle `ignore_changes` worked for read and write capacity on the table but there was no solution for GSI.  New flag works consistently for both.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
